### PR TITLE
[BUGFIX] add missing EXT:vhs dependency

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -26,6 +26,7 @@ $EM_CONF[$_EXTKEY] = array (
     array (
       'typo3' => '10.4.0-11.5.99',
       'tt_address' => '5.0.0-5.2.99',
+      'vhs'
     ),
     'conflicts' => 
     array (


### PR DESCRIPTION
Vhs viewhelper iterator.sort is used in Resources/Private/Templates/Address/List.html.